### PR TITLE
Add SSR views for Sleeper league rosters and players

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v2
+      - name: Run checks
+        run: deno task check
+      - name: Run tests
+        run: deno test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Sleeperapp
 
-This repository contains a minimal [Fresh](https://fresh.deno.dev) web
-application built with Deno.
+This repository contains a [Fresh](https://fresh.deno.dev) web application built
+with Deno that renders data from the [Sleeper](https://sleeper.com) fantasy
+football API. The home page lists rosters for league `1248432621554237440` and
+the `/players` route shows an alphabetical list of players.
 
 ## Development
 

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -7,6 +7,7 @@ import * as $_app from "./routes/_app.tsx";
 import * as $api_joke from "./routes/api/joke.ts";
 import * as $greet_name_ from "./routes/greet/[name].tsx";
 import * as $index from "./routes/index.tsx";
+import * as $players from "./routes/players.tsx";
 import * as $Counter from "./islands/Counter.tsx";
 import type { Manifest } from "$fresh/server.ts";
 
@@ -17,6 +18,7 @@ const manifest = {
     "./routes/api/joke.ts": $api_joke,
     "./routes/greet/[name].tsx": $greet_name_,
     "./routes/index.tsx": $index,
+    "./routes/players.tsx": $players,
   },
   islands: {
     "./islands/Counter.tsx": $Counter,

--- a/lib/sleeper.ts
+++ b/lib/sleeper.ts
@@ -1,0 +1,59 @@
+export interface SleeperRoster {
+  roster_id: number;
+  owner_id: string;
+  players: string[];
+}
+
+export interface SleeperPlayer {
+  full_name: string;
+}
+
+export interface SleeperUser {
+  user_id: string;
+  display_name: string;
+}
+
+export interface Roster {
+  owner: string;
+  players: string[];
+}
+
+export function buildRosters(
+  rosters: SleeperRoster[],
+  players: Record<string, SleeperPlayer>,
+  users: SleeperUser[],
+): Roster[] {
+  const userMap = new Map(users.map((u) => [u.user_id, u.display_name]));
+
+  return rosters.map((r) => ({
+    owner: userMap.get(r.owner_id) ?? `Roster ${r.roster_id}`,
+    players: (r.players ?? []).map((id) => players[id]?.full_name ?? id),
+  }));
+}
+
+export interface RawPlayer {
+  player_id: string;
+  full_name: string;
+  position?: string;
+  team?: string;
+}
+
+export interface Player {
+  id: string;
+  name: string;
+  position: string;
+  team: string | null;
+}
+
+export function buildPlayers(data: Record<string, RawPlayer>): Player[] {
+  return Object.values(data)
+    .filter((p) => p.position)
+    .sort((a, b) => a.full_name.localeCompare(b.full_name))
+    .slice(0, 50)
+    .map((p) => ({
+      id: p.player_id,
+      name: p.full_name,
+      position: p.position!,
+      team: p.team ?? null,
+    }));
+}

--- a/lib/sleeper_test.ts
+++ b/lib/sleeper_test.ts
@@ -1,0 +1,34 @@
+import { assertEquals } from "$std/assert/mod.ts";
+import { buildPlayers, buildRosters } from "./sleeper.ts";
+
+Deno.test("buildRosters maps owners and players", () => {
+  const rosters = [
+    { roster_id: 1, owner_id: "u1", players: ["p1", "p2"] },
+    { roster_id: 2, owner_id: "u2", players: [] },
+  ];
+  const players = {
+    p1: { full_name: "Player One" },
+    p2: { full_name: "Player Two" },
+  };
+  const users = [
+    { user_id: "u1", display_name: "Alice" },
+  ];
+  const result = buildRosters(rosters, players, users);
+  assertEquals(result, [
+    { owner: "Alice", players: ["Player One", "Player Two"] },
+    { owner: "Roster 2", players: [] },
+  ]);
+});
+
+Deno.test("buildPlayers sorts and limits players", () => {
+  const data = {
+    a: { player_id: "a", full_name: "Beta", position: "RB" },
+    b: { player_id: "b", full_name: "Alpha", position: "QB" },
+    c: { player_id: "c", full_name: "Gamma" },
+  };
+  const result = buildPlayers(data);
+  assertEquals(result, [
+    { id: "b", name: "Alpha", position: "QB", team: null },
+    { id: "a", name: "Beta", position: "RB", team: null },
+  ]);
+});

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,18 +1,59 @@
-import { useSignal } from "@preact/signals";
-import Counter from "../islands/Counter.tsx";
+import { Handlers, PageProps } from "$fresh/server.ts";
 
-export default function Home() {
-  const count = useSignal(3);
+interface Roster {
+  owner: string;
+  players: string[];
+}
+
+export const handler: Handlers<{ rosters: Roster[] }> = {
+  async GET(_req, ctx) {
+    const leagueId = "1248432621554237440";
+    const [rostersRes, playersRes, usersRes] = await Promise.all([
+      fetch(`https://api.sleeper.app/v1/league/${leagueId}/rosters`),
+      fetch("https://api.sleeper.app/v1/players/nfl"),
+      fetch(`https://api.sleeper.app/v1/league/${leagueId}/users`),
+    ]);
+
+    const rostersData = await rostersRes.json();
+    const playersData = await playersRes.json();
+    const usersData = await usersRes.json();
+
+    const users = new Map(
+      usersData.map((u: { user_id: string; display_name: string }) => [
+        u.user_id,
+        u.display_name,
+      ]),
+    );
+
+    const rosters = rostersData.map((r: {
+      roster_id: number;
+      owner_id: string;
+      players: string[];
+    }) => ({
+      owner: users.get(r.owner_id) ?? `Roster ${r.roster_id}`,
+      players: (r.players ?? []).map(
+        (id: string) => playersData[id]?.full_name ?? id,
+      ),
+    }));
+
+    return ctx.render({ rosters });
+  },
+};
+
+export default function Home(
+  { data }: PageProps<{ rosters: Roster[] }>,
+) {
   return (
-    <div class="px-4 py-8 mx-auto bg-[#86efac]">
-      <div class="max-w-screen-md mx-auto flex flex-col items-center justify-center">
-        <h1 class="text-4xl font-bold my-6">Welcome to Fresh</h1>
-        <p class="my-4">
-          Try updating this message in the
-          <code class="mx-2">./routes/index.tsx</code> file, and refresh.
-        </p>
-        <Counter count={count} />
-      </div>
-    </div>
+    <main class="p-4 mx-auto max-w-screen-md">
+      <h1 class="text-2xl font-bold mb-4">League Rosters</h1>
+      {data.rosters.map((roster) => (
+        <div class="mb-6">
+          <h2 class="text-xl font-semibold">{roster.owner}</h2>
+          <ul class="list-disc list-inside">
+            {roster.players.map((p) => <li key={p}>{p}</li>)}
+          </ul>
+        </div>
+      ))}
+    </main>
   );
 }

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,9 +1,5 @@
 import { Handlers, PageProps } from "$fresh/server.ts";
-
-interface Roster {
-  owner: string;
-  players: string[];
-}
+import { buildRosters, type Roster } from "../lib/sleeper.ts";
 
 export const handler: Handlers<{ rosters: Roster[] }> = {
   async GET(_req, ctx) {
@@ -18,23 +14,7 @@ export const handler: Handlers<{ rosters: Roster[] }> = {
     const playersData = await playersRes.json();
     const usersData = await usersRes.json();
 
-    const users = new Map(
-      usersData.map((u: { user_id: string; display_name: string }) => [
-        u.user_id,
-        u.display_name,
-      ]),
-    );
-
-    const rosters = rostersData.map((r: {
-      roster_id: number;
-      owner_id: string;
-      players: string[];
-    }) => ({
-      owner: users.get(r.owner_id) ?? `Roster ${r.roster_id}`,
-      players: (r.players ?? []).map(
-        (id: string) => playersData[id]?.full_name ?? id,
-      ),
-    }));
+    const rosters = buildRosters(rostersData, playersData, usersData);
 
     return ctx.render({ rosters });
   },

--- a/routes/players.tsx
+++ b/routes/players.tsx
@@ -1,34 +1,12 @@
 import { Handlers, PageProps } from "$fresh/server.ts";
-
-interface Player {
-  id: string;
-  name: string;
-  position: string;
-  team: string | null;
-}
-
-interface RawPlayer {
-  player_id: string;
-  full_name: string;
-  position?: string;
-  team?: string;
-}
+import { buildPlayers, type Player } from "../lib/sleeper.ts";
 
 export const handler: Handlers<{ players: Player[] }> = {
   async GET(_req, ctx) {
     const res = await fetch("https://api.sleeper.app/v1/players/nfl");
-    const data = (await res.json()) as Record<string, RawPlayer>;
+    const data = await res.json();
 
-    const players: Player[] = Object.values(data)
-      .filter((p) => p.position)
-      .sort((a, b) => a.full_name.localeCompare(b.full_name))
-      .slice(0, 50)
-      .map((p) => ({
-        id: p.player_id,
-        name: p.full_name,
-        position: p.position!,
-        team: p.team ?? null,
-      }));
+    const players: Player[] = buildPlayers(data);
 
     return ctx.render({ players });
   },

--- a/routes/players.tsx
+++ b/routes/players.tsx
@@ -1,0 +1,52 @@
+import { Handlers, PageProps } from "$fresh/server.ts";
+
+interface Player {
+  id: string;
+  name: string;
+  position: string;
+  team: string | null;
+}
+
+interface RawPlayer {
+  player_id: string;
+  full_name: string;
+  position?: string;
+  team?: string;
+}
+
+export const handler: Handlers<{ players: Player[] }> = {
+  async GET(_req, ctx) {
+    const res = await fetch("https://api.sleeper.app/v1/players/nfl");
+    const data = (await res.json()) as Record<string, RawPlayer>;
+
+    const players: Player[] = Object.values(data)
+      .filter((p) => p.position)
+      .sort((a, b) => a.full_name.localeCompare(b.full_name))
+      .slice(0, 50)
+      .map((p) => ({
+        id: p.player_id,
+        name: p.full_name,
+        position: p.position!,
+        team: p.team ?? null,
+      }));
+
+    return ctx.render({ players });
+  },
+};
+
+export default function PlayersPage(
+  { data }: PageProps<{ players: Player[] }>,
+) {
+  return (
+    <main class="p-4 mx-auto max-w-screen-md">
+      <h1 class="text-2xl font-bold mb-4">Players</h1>
+      <ul class="space-y-1">
+        {data.players.map((p) => (
+          <li key={p.id}>
+            {p.name} - {p.team ?? "FA"} {p.position}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch rosters, users, and players for Sleeper league `1248432621554237440` on server and render them on the home page
- add `/players` route showing an alphabetical list of the first 50 Sleeper NFL players
- document Sleeper integration and league/players pages in README

## Testing
- `deno task manifest`
- `deno fmt`
- `deno task check`

------
https://chatgpt.com/codex/tasks/task_e_68b3a9001bc48326b807ef6a1da97f40