### PR TITLE
Add Sleeper API proxy and league pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,15 @@
 
 This repository contains a [Fresh](https://fresh.deno.dev) web application built
 with Deno that renders data from the [Sleeper](https://sleeper.com) fantasy
-football API. The home page lists rosters for league `1248432621554237440` and
-the `/players` route shows an alphabetical list of players.
+football API. The home page lists rosters for league `1248432621554237440`.
+Additional routes expose more league information:
+
+- `/players` – alphabetical list of NFL players
+- `/league` – basic info about the league
+- `/matchups` – week 1 matchups for the league
+
+Most Sleeper API endpoints are proxied through `/api/sleeper/*` which forwards
+requests to `https://api.sleeper.app/v1/`.
 
 ## Development
 

--- a/routes/api/sleeper/[...path].ts
+++ b/routes/api/sleeper/[...path].ts
@@ -1,0 +1,29 @@
+import { Handlers } from "$fresh/server.ts";
+
+async function proxy(req: Request, ctx: { params: Record<string, string> }) {
+  const url = new URL(req.url);
+  const target = `https://api.sleeper.app/v1/${ctx.params.path}${url.search}`;
+  const res = await fetch(target, {
+    method: req.method,
+    headers: req.headers,
+    body: req.method === "GET" || req.method === "HEAD" ? undefined : req.body,
+  });
+  const headers = new Headers(res.headers);
+  headers.set("Access-Control-Allow-Origin", "*");
+  return new Response(res.body, { status: res.status, headers });
+}
+
+export const handler: Handlers = {
+  GET: proxy,
+  POST: proxy,
+  PUT: proxy,
+  PATCH: proxy,
+  DELETE: proxy,
+  OPTIONS(_req) {
+    const headers = new Headers({
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
+    });
+    return new Response(null, { headers });
+  },
+};

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -25,6 +25,11 @@ export default function Home(
 ) {
   return (
     <main class="p-4 mx-auto max-w-screen-md">
+      <nav class="mb-4 space-x-4">
+        <a href="/players" class="underline">Players</a>
+        <a href="/league" class="underline">League Info</a>
+        <a href="/matchups" class="underline">Matchups</a>
+      </nav>
       <h1 class="text-2xl font-bold mb-4">League Rosters</h1>
       {data.rosters.map((roster) => (
         <div class="mb-6">

--- a/routes/league.tsx
+++ b/routes/league.tsx
@@ -1,0 +1,40 @@
+import { Handlers, PageProps } from "$fresh/server.ts";
+
+interface LeagueData {
+  name: string;
+  season: string;
+  totalRosters: number;
+}
+
+export const handler: Handlers<LeagueData> = {
+  async GET(_req, ctx) {
+    const leagueId = "1248432621554237440";
+    const res = await fetch(`https://api.sleeper.app/v1/league/${leagueId}`);
+    const data = await res.json();
+    const league = {
+      name: data.name,
+      season: data.season,
+      totalRosters: data.total_rosters,
+    };
+    return ctx.render(league);
+  },
+};
+
+export default function LeaguePage(
+  { data }: PageProps<LeagueData>,
+) {
+  return (
+    <main class="p-4 mx-auto max-w-screen-md">
+      <h1 class="text-2xl font-bold mb-4">League Info</h1>
+      <p>
+        <span class="font-semibold">Name:</span> {data.name}
+      </p>
+      <p>
+        <span class="font-semibold">Season:</span> {data.season}
+      </p>
+      <p>
+        <span class="font-semibold">Total Rosters:</span> {data.totalRosters}
+      </p>
+    </main>
+  );
+}

--- a/routes/matchups.tsx
+++ b/routes/matchups.tsx
@@ -1,0 +1,36 @@
+import { Handlers, PageProps } from "$fresh/server.ts";
+
+interface Matchup {
+  matchup_id: number;
+  roster_id: number;
+  points: number;
+}
+
+export const handler: Handlers<{ matchups: Matchup[] }> = {
+  async GET(_req, ctx) {
+    const leagueId = "1248432621554237440";
+    const week = 1;
+    const res = await fetch(
+      `https://api.sleeper.app/v1/league/${leagueId}/matchups/${week}`,
+    );
+    const data = await res.json();
+    return ctx.render({ matchups: data });
+  },
+};
+
+export default function MatchupsPage(
+  { data }: PageProps<{ matchups: Matchup[] }>,
+) {
+  return (
+    <main class="p-4 mx-auto max-w-screen-md">
+      <h1 class="text-2xl font-bold mb-4">Week 1 Matchups</h1>
+      <ul class="space-y-1">
+        {data.matchups.map((m) => (
+          <li key={`${m.matchup_id}-${m.roster_id}`}>
+            Matchup {m.matchup_id}: Roster {m.roster_id} - {m.points} pts
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- expose Sleeper API through `/api/sleeper/*` proxy
- add league info and week 1 matchup pages
- link new pages from home

## Testing
- `deno test` *(failed: invalid peer certificate UnknownIssuer)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b7e89fe08326836693ec17bc799e